### PR TITLE
Add protected directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,4 @@ The following attributes are available for `mcvella:data:mirror`:
 | `dataset_id` | string | Optional |  Data management dataset ID to filter on. |
 | `mirror_path` | string | Optional | Path on target machine to sync to, defaults to <home>/.viam/data_mirror. Requested path will be created relative to <home>/.viam/ |
 | `delete` | boolean | Optional |  If set to true, will delete files in mirror_path that do not exist in data management. |
+| `protected_dirs` | list | Optional |  Directory names, relative to `mirror path`, that should never be removed (even if empty). |


### PR DESCRIPTION
Add `protected_dirs` to protect selected directories from deletion:
* Users can specify a list of directories (relative to the mirror root) that should never be removed (even if empty)
* Helps with scenarios where other processes expect certain directories to exist at all times
* Adds a new attribute (`protected_dirs`) in the `mirror` class (defaults to an empty list)
* If `protected_dirs` is not specified, the behavior remains unchanged from the previous version
    * All empty directories get removed, except the root mirror directory
* In the `reconfigure` method, `protected_dirs` is read as a list from the component's attributes
* In `remove_empty_dirs`, directories that match the relative paths in `protected_dirs` get skipped for cleanup

Example: add `protected_dirs` in your component's configuration:
```
{
  "protected_dirs": ["face", "profile"]
}
```
